### PR TITLE
removed dependancy to go-bindata-assetfs and corrected usage

### DIFF
--- a/example/bindata/bindata.go
+++ b/example/bindata/bindata.go
@@ -1,15 +1,22 @@
+// Code generated for package main by go-bindata DO NOT EDIT. (@generated)
+// sources:
+// data/index.html
 package main
 
 import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"net/http"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
-func bindata_read(data []byte, name string) ([]byte, error) {
+func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("Read %q: %v", name, err)
@@ -17,34 +24,165 @@ func bindata_read(data []byte, name string) ([]byte, error) {
 
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, gz)
-	gz.Close()
+	clErr := gz.Close()
 
 	if err != nil {
 		return nil, fmt.Errorf("Read %q: %v", name, err)
+	}
+	if clErr != nil {
+		return nil, err
 	}
 
 	return buf.Bytes(), nil
 }
 
-func data_index_html() ([]byte, error) {
-	return bindata_read([]byte{
-		0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x00, 0xff, 0x44, 0xce,
-		0xbd, 0xae, 0xc2, 0x30, 0x0c, 0x05, 0xe0, 0xbd, 0x4f, 0xe1, 0x9b, 0xbd,
-		0xaa, 0xba, 0xdd, 0x21, 0xcd, 0xc2, 0xef, 0x06, 0x43, 0x19, 0x18, 0x5d,
-		0x62, 0x35, 0x41, 0x4e, 0x22, 0x15, 0x4b, 0x88, 0xb7, 0x27, 0x21, 0x45,
-		0x4c, 0x39, 0xb1, 0xf5, 0x1d, 0x59, 0xff, 0x6d, 0x4f, 0x9b, 0xf1, 0x7a,
-		0xde, 0x81, 0x93, 0xc0, 0xa6, 0xd1, 0xe5, 0x01, 0xc6, 0x38, 0x0f, 0xea,
-		0x8e, 0xca, 0x34, 0x00, 0xda, 0x11, 0xda, 0x12, 0x72, 0x0c, 0x24, 0x08,
-		0x37, 0x87, 0xcb, 0x83, 0x64, 0x50, 0x97, 0x71, 0xdf, 0xfe, 0x2b, 0xe8,
-		0xd6, 0xa5, 0x78, 0x61, 0x32, 0x73, 0x6a, 0x27, 0x1f, 0x2d, 0x0a, 0xea,
-		0xae, 0x4e, 0x4a, 0x47, 0xf7, 0x2d, 0xd1, 0x53, 0xb2, 0xaf, 0x15, 0xb8,
-		0xde, 0x1c, 0x89, 0x39, 0xc1, 0xc1, 0x47, 0xf8, 0x39, 0x08, 0xde, 0x5a,
-		0xa6, 0x27, 0x2e, 0x94, 0x5d, 0x5f, 0x7d, 0x65, 0xf9, 0xff, 0x39, 0xf3,
-		0x1d, 0x00, 0x00, 0xff, 0xff, 0x51, 0x69, 0x85, 0x27, 0xb7, 0x00, 0x00,
-		0x00,
-	},
-		"data/index.html",
+type asset struct {
+	bytes []byte
+	info  os.FileInfo
+}
+
+type bindataFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+}
+
+// Name return file name
+func (fi bindataFileInfo) Name() string {
+	return fi.name
+}
+
+// Size return file size
+func (fi bindataFileInfo) Size() int64 {
+	return fi.size
+}
+
+// Mode return file mode
+func (fi bindataFileInfo) Mode() os.FileMode {
+	return fi.mode
+}
+
+// Mode return file modify time
+func (fi bindataFileInfo) ModTime() time.Time {
+	return fi.modTime
+}
+
+// IsDir return file whether a directory
+func (fi bindataFileInfo) IsDir() bool {
+	return fi.mode&os.ModeDir != 0
+}
+
+// Sys return file is sys mode
+func (fi bindataFileInfo) Sys() interface{} {
+	return nil
+}
+
+
+type assetFile struct {
+	*bytes.Reader
+	name            string
+	childInfos      []os.FileInfo
+	childInfoOffset int
+}
+
+type assetOperator struct{}
+
+// Open implement http.FileSystem interface
+func (f *assetOperator) Open(name string) (http.File, error) {
+	var err error
+	if len(name) > 0 && name[0] == '/' {
+		name = name[1:]
+	}
+	content, err := Asset(name)
+	if err == nil {
+		return &assetFile{name: name, Reader: bytes.NewReader(content)}, nil
+	}
+	children, err := AssetDir(name)
+	if err == nil {
+		childInfos := make([]os.FileInfo, 0, len(children))
+		for _, child := range children {
+			childPath := filepath.Join(name, child)
+			info, errInfo := AssetInfo(filepath.Join(name, child))
+			if errInfo == nil {
+				childInfos = append(childInfos, info)
+			} else {
+				childInfos = append(childInfos, newDirFileInfo(childPath))
+			}
+		}
+		return &assetFile{name: name, childInfos: childInfos}, nil
+	} else {
+		// If the error is not found, return an error that will
+		// result in a 404 error. Otherwise the server returns
+		// a 500 error for files not found.
+		if strings.Contains(err.Error(), "not found") {
+			return nil, os.ErrNotExist
+		}
+		return nil, err
+	}
+}
+
+// Close no need do anything
+func (f *assetFile) Close() error {
+	return nil
+}
+
+// Readdir read dir's children file info
+func (f *assetFile) Readdir(count int) ([]os.FileInfo, error) {
+	if len(f.childInfos) == 0 {
+		return nil, os.ErrNotExist
+	}
+	if count <= 0 {
+		return f.childInfos, nil
+	}
+	if f.childInfoOffset+count > len(f.childInfos) {
+		count = len(f.childInfos) - f.childInfoOffset
+	}
+	offset := f.childInfoOffset
+	f.childInfoOffset += count
+	return f.childInfos[offset : offset+count], nil
+}
+
+// Stat read file info from asset item
+func (f *assetFile) Stat() (os.FileInfo, error) {
+	if len(f.childInfos) != 0 {
+		return newDirFileInfo(f.name), nil
+	}
+	return AssetInfo(f.name)
+}
+
+// newDirFileInfo return default dir file info
+func newDirFileInfo(name string) os.FileInfo {
+	return &bindataFileInfo{
+		name:    name,
+		size:    0,
+		mode:    os.FileMode(2147484068), // equal os.FileMode(0644)|os.ModeDir
+		modTime: time.Time{}}
+}
+
+// AssetFile return a http.FileSystem instance that data backend by asset
+func AssetFile() http.FileSystem {
+	return &assetOperator{}
+}
+
+var _indexHtml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x44\xce\x3d\x0e\xc2\x30\x0c\x05\xe0\xbd\xa7\x30\xd9\xab\xa8\x1b\x83\x9b\x85\xdf\x0d\x86\x32\x30\xba\xc4\x6a\x82\xdc\x44\x2a\x96\x10\xb7\x47\x51\x8a\x98\x6c\xd9\xfa\x9e\x1e\x6e\xf6\x97\xdd\x70\xbf\x1e\x20\xe8\x2c\xae\xc1\x32\x40\x28\x4d\xbd\x79\x92\x71\x0d\x00\x06\x26\x5f\x16\x00\x9c\x59\x09\x1e\x81\x96\x17\x6b\x6f\x6e\xc3\xb1\xdd\x1a\xb0\xeb\x53\xa3\x0a\xbb\x29\xb7\x63\x4c\x9e\x94\xd0\xd6\x4b\xc9\xb0\xbf\x10\x1c\xb3\xff\xac\x20\x74\xee\xcc\x22\x19\x4e\x31\xc1\xdf\xc1\x1c\xbd\x17\x7e\xd3\xc2\x68\x43\x57\x7d\x65\x68\x6b\xcd\x6f\x00\x00\x00\xff\xff\x51\x69\x85\x27\xb7\x00\x00\x00")
+
+func indexHtmlBytes() ([]byte, error) {
+	return bindataRead(
+		_indexHtml,
+		"index.html",
 	)
+}
+
+func indexHtml() (*asset, error) {
+	bytes, err := indexHtmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "index.html", size: 183, mode: os.FileMode(438), modTime: time.Unix(1605622202, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
 }
 
 // Asset loads and returns the asset for the given name.
@@ -53,9 +191,39 @@ func data_index_html() ([]byte, error) {
 func Asset(name string) ([]byte, error) {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[cannonicalName]; ok {
-		return f()
+		a, err := f()
+		if err != nil {
+			return nil, fmt.Errorf("Asset %s can't read by error: %v", name, err)
+		}
+		return a.bytes, nil
 	}
 	return nil, fmt.Errorf("Asset %s not found", name)
+}
+
+// MustAsset is like Asset but panics when Asset would return an error.
+// It simplifies safe initialization of global variables.
+func MustAsset(name string) []byte {
+	a, err := Asset(name)
+	if err != nil {
+		panic("asset: Asset(" + name + "): " + err.Error())
+	}
+
+	return a
+}
+
+// AssetInfo loads and returns the asset info for the given name.
+// It returns an error if the asset could not be found or
+// could not be loaded.
+func AssetInfo(name string) (os.FileInfo, error) {
+	cannonicalName := strings.Replace(name, "\\", "/", -1)
+	if f, ok := _bindata[cannonicalName]; ok {
+		a, err := f()
+		if err != nil {
+			return nil, fmt.Errorf("AssetInfo %s can't read by error: %v", name, err)
+		}
+		return a.info, nil
+	}
+	return nil, fmt.Errorf("AssetInfo %s not found", name)
 }
 
 // AssetNames returns the names of the assets.
@@ -68,8 +236,8 @@ func AssetNames() []string {
 }
 
 // _bindata is a table, holding each asset generator, mapped to its name.
-var _bindata = map[string]func() ([]byte, error){
-	"data/index.html": data_index_html,
+var _bindata = map[string]func() (*asset, error){
+	"index.html": indexHtml,
 }
 
 // AssetDir returns the file names below a certain
@@ -84,38 +252,81 @@ var _bindata = map[string]func() ([]byte, error){
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error
+// AssetDir("") will return []string{"data"}.
 func AssetDir(name string) ([]string, error) {
-	cannonicalName := strings.Replace(name, "\\", "/", -1)
-	pathList := strings.Split(cannonicalName, "/")
 	node := _bintree
-	for _, p := range pathList {
-		node = node.Children[p]
-		if node == nil {
-			return nil, fmt.Errorf("Asset %s not found", name)
+	if len(name) != 0 {
+		cannonicalName := strings.Replace(name, "\\", "/", -1)
+		pathList := strings.Split(cannonicalName, "/")
+		for _, p := range pathList {
+			node = node.Children[p]
+			if node == nil {
+				return nil, fmt.Errorf("Asset %s not found", name)
+			}
 		}
 	}
 	if node.Func != nil {
 		return nil, fmt.Errorf("Asset %s not found", name)
 	}
 	rv := make([]string, 0, len(node.Children))
-	for name := range node.Children {
-		rv = append(rv, name)
+	for childName := range node.Children {
+		rv = append(rv, childName)
 	}
 	return rv, nil
 }
 
-type _bintree_t struct {
-	Func     func() ([]byte, error)
-	Children map[string]*_bintree_t
+type bintree struct {
+	Func     func() (*asset, error)
+	Children map[string]*bintree
 }
 
-var _bintree = &_bintree_t{nil, map[string]*_bintree_t{
-	"data": &_bintree_t{nil, map[string]*_bintree_t{
-		"index.html": &_bintree_t{data_index_html, map[string]*_bintree_t{}},
-	}},
+var _bintree = &bintree{nil, map[string]*bintree{
+	"index.html": &bintree{indexHtml, map[string]*bintree{}},
 }}
 
-// AssetInfo returns file info of given path
-func AssetInfo(path string) (os.FileInfo, error) {
-	return os.Stat(path)
+// RestoreAsset restores an asset under the given directory
+func RestoreAsset(dir, name string) error {
+	data, err := Asset(name)
+	if err != nil {
+		return err
+	}
+	info, err := AssetInfo(name)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	if err != nil {
+		return err
+	}
+	err = os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RestoreAssets restores an asset under the given directory recursively
+func RestoreAssets(dir, name string) error {
+	children, err := AssetDir(name)
+	// File
+	if err != nil {
+		return RestoreAsset(dir, name)
+	}
+	// Dir
+	for _, child := range children {
+		err = RestoreAssets(dir, filepath.Join(name, child))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func _filePath(dir, name string) string {
+	cannonicalName := strings.Replace(name, "\\", "/", -1)
+	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }

--- a/example/bindata/example.go
+++ b/example/bindata/example.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
 )
@@ -28,21 +27,20 @@ func (b *binaryFileSystem) Exists(prefix string, filepath string) bool {
 	return false
 }
 
-func BinaryFileSystem(root string) *binaryFileSystem {
-	fs := &assetfs.AssetFS{Asset, AssetDir, AssetInfo, root}
+func binaryFS(root string) *binaryFileSystem {
 	return &binaryFileSystem{
-		fs,
+		AssetFile(),
 	}
 }
 
 // Usage
-// $ go-bindata data/
+// $ go-bindata -prefix "data" -fs data/
 // $ go build && ./bindata
 //
 func main() {
 	r := gin.Default()
 
-	r.Use(static.Serve("/static", BinaryFileSystem("data")))
+	r.Use(static.Serve("/static", binaryFS("data")))
 	r.GET("/ping", func(c *gin.Context) {
 		c.String(200, "test")
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/gin-contrib/static
 
 require (
-	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/gin-gonic/gin v1.5.0
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
-github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.5.0 h1:fi+bqFAx/oLK54somfCtEZs9HeH1LHVoEPUgARpTqyc=


### PR DESCRIPTION
last versions of go-bindata will bundle the necessary FS functions inside the generated .go file if you add -fs option when generating it, thus rendering the "go-bindata-assetfs" import obsolete, and altering the way you need to implement the binaryFS function (also renamed to corrected first letter case and still be readable)

Hence I corrected the example "bindata" to be up to date.