### PR TITLE
fix: also trim perfix in embedfs

### DIFF
--- a/embed_folder.go
+++ b/embed_folder.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"strings"
 )
 
 type embedFileSystem struct {
@@ -12,7 +13,7 @@ type embedFileSystem struct {
 }
 
 func (e embedFileSystem) Exists(prefix string, path string) bool {
-	_, err := e.Open(path)
+	_, err := e.Open(strings.TrimPrefix(path, prefix))
 	return err == nil
 }
 


### PR DESCRIPTION
https://github.com/gin-contrib/static/blob/722aa5b1b50674374c91c98e37fd426eff79c60b/serve.go#L19-L30

We prune the perfix in http.FileServer, but not in the Exist function.
This makes not possible to serve specific subfolder in embed.Fs.

```go
//go:embed public/*
var staticfs embed.FS
func (engine *gin.Engine) {
	engine.Use(static.Serve("/static", static.EmbedFolder(staticfs, "public/static")))
}
```
