### PR TITLE
chore(embed): improve error handling for EmbedFolder function

### DIFF
--- a/embed_folder.go
+++ b/embed_folder.go
@@ -2,30 +2,41 @@ package static
 
 import (
 	"embed"
+	"errors"
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"strings"
 )
 
+// embedFileSystem is a struct that implements the http.FileSystem interface for embedding a file system.
 type embedFileSystem struct {
 	http.FileSystem
 }
 
+// Exists method checks if the given file path exists in the embedded file system.
+// If the path exists, it returns true; otherwise, it returns false.
 func (e embedFileSystem) Exists(prefix string, path string) bool {
+	if len(prefix) > 1 && strings.HasPrefix(path, prefix) {
+		path = strings.TrimPrefix(path, prefix)
+	}
+
 	_, err := e.Open(path)
 	return err == nil
 }
 
-func EmbedFolder(fsEmbed embed.FS, targetPath string) ServeFileSystem {
+// EmbedFolder function embeds the target folder from the embedded file system into the ServeFileSystem.
+// If an error occurs during the embedding process, it returns the error message.
+func EmbedFolder(fsEmbed embed.FS, targetPath string) (ServeFileSystem, error) {
 	fsys, err := fs.Sub(fsEmbed, targetPath)
 	if err != nil {
 		slog.Error("Failed to embed folder",
 			"targetPath", targetPath,
 			"error", err,
 		)
-		return nil
+		return nil, errors.New("failed to embed folder: " + err.Error())
 	}
 	return embedFileSystem{
 		FileSystem: http.FS(fsys),
-	}
+	}, nil
 }

--- a/embed_folder_test.go
+++ b/embed_folder_test.go
@@ -12,6 +12,7 @@ import (
 //go:embed test/data/server
 var server embed.FS
 
+// embedTests 定義了一組測試用例，用於測試嵌入文件系統的行為。
 var embedTests = []struct {
 	targetURL string // input
 	httpCode  int    // expected http code
@@ -24,9 +25,14 @@ var embedTests = []struct {
 	{"/static.html", 200, "<h1>Hello Gin Static</h1>", "Other file"},
 }
 
+// TestEmbedFolder 測試 EmbedFolder 函數的行為，確保其能夠正確嵌入文件夾並提供靜態文件服務。
 func TestEmbedFolder(t *testing.T) {
 	router := gin.New()
-	router.Use(Serve("/", EmbedFolder(server, "test/data/server")))
+	fs, err := EmbedFolder(server, "test/data/server")
+	if err != nil {
+		t.Fatalf("Failed to embed folder: %v", err)
+	}
+	router.Use(Serve("/", fs))
 	router.NoRoute(func(c *gin.Context) {
 		fmt.Printf("%s doesn't exists, redirect on /\n", c.Request.URL.Path)
 		c.Redirect(301, "/")


### PR DESCRIPTION
- Add error handling for the `EmbedFolder` function
- Add comments explaining the `embedFileSystem` struct and its `Exists` method
- Add imports for `errors` and `strings` packages
- Update `TestEmbedFolder` to handle errors from `EmbedFolder` function
- Add comments in `embed_folder_test.go` in Chinese for test case explanations

fix https://github.com/gin-contrib/static/issues/57